### PR TITLE
Update to LodestoneLib 0.0.5+1.20.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ quilt-quiltedFabricApi = "7.4.0+0.90.0-1.20.1"
 # Third party dependencies
 # The latest versions should be available at https://ladysnake.org/tools/dependencies
 iris = "1.6.11+1.20.1"
-lodestoneLib = "0.0.4+1.20.1"
+lodestoneLib = "0.0.5+1.20.1"
 midnightLib = "1.4.1-quilt"
 modmenu = "7.2.2"
 satin = "1.14.0"


### PR DESCRIPTION
This removes the infamous jesser log message, as discussed

This requires a Ladysnake person to publish the new update from [this state](https://github.com/Arathain/LodestoneLib-Quilt/tree/1.19.3) so that 0.0.5+1.20.1 will actually exist